### PR TITLE
Allow chapter navigation buttons to be rendered in other statuses

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -258,6 +258,15 @@ Filters the intermediate output array of the chapter micro menu in the `fictione
 
 ---
 
+### `apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_status', $statuses, $post_id )`
+Filters the array of allowed post statuses for the chapter navigation buttons in the `fictioneer_chapter_nav_buttons( $args, $location )` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the navigation to render with these statuses.
+
+**Parameters:**
+* $statuses (array) – Array of allowed post statuses.
+* $post_id (int) – Current post ID.
+
+---
+
 ### `apply_filters( 'fictioneer_filter_chapter_support_links', $support_links, $args )`
 Filters the intermediate output array of the chapter support links in the `fictioneer_chapter_support_links( $args )` function before it is looped and rendered. Each item is another array with `'label'`, `'icon'` markup, and `'link'`.
 

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -275,7 +275,7 @@ Filters the array of allowed post statuses for the chapter navigation buttons in
 
 ---
 
-### `apply_filters( 'fictioneer_filter_fictioneer_chapter_subscribe_button_statuses', $statuses, $post_id )`
+### `apply_filters( 'fictioneer_filter_chapter_subscribe_button_statuses', $statuses, $post_id )`
 Filters the array of allowed post statuses for the chapter subscribe button in the `fictioneer_chapter_subscribe_button()` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the button to render with these statuses.
 
 **Parameters:**
@@ -284,7 +284,7 @@ Filters the array of allowed post statuses for the chapter subscribe button in t
 
 ---
 
-### `apply_filters( 'fictioneer_filter_fictioneer_chapter_index_popup_menu_statuses', $statuses, $post_id, $story_id )`
+### `apply_filters( 'fictioneer_filter_chapter_index_popup_menu_statuses', $statuses, $post_id, $story_id )`
 Filters the array of allowed post statuses for the chapter index popup menu in the `fictioneer_chapter_index_popup_menu( $args )` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the menu to render with these statuses.
 
 **Parameters:**
@@ -294,7 +294,7 @@ Filters the array of allowed post statuses for the chapter index popup menu in t
 
 ---
 
-### `apply_filters( 'fictioneer_filter_fictioneer_chapter_media_buttons_statuses', $statuses, $post_id )`
+### `apply_filters( 'fictioneer_filter_chapter_media_buttons_statuses', $statuses, $post_id )`
 Filters the array of allowed post statuses for the chapter media buttons in the `fictioneer_chapter_media_buttons()` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the buttons to render with these statuses.
 
 **Parameters:**

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -258,8 +258,44 @@ Filters the intermediate output array of the chapter micro menu in the `fictione
 
 ---
 
-### `apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', $statuses, $post_id )`
+### `apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', $statuses, $post_id, $args, $location )`
 Filters the array of allowed post statuses for the chapter navigation buttons in the `fictioneer_chapter_nav_buttons( $args, $location )` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the navigation to render with these statuses.
+
+**Parameters:**
+* $statuses (array) – Array of allowed post statuses.
+* $post_id (int) – Current post ID.
+* $args (array) – Arguments passed to the function.
+* $location (string) – Location of the navigation. Either `'top'` or `'bottom'`.
+
+**$args:**
+* $chapter_ids (array) – IDs of visible chapters in the same story or empty array.
+* $indexed_chapter_ids (array) – IDs of accessible chapters in the same story or empty array.
+* $prev_index (int|boolean) – Index of previous chapter or false if outside bounds.
+* $next_index (int|boolean) – Index of next chapter or false if outside bounds.
+
+---
+
+### `apply_filters( 'fictioneer_filter_fictioneer_chapter_subscribe_button_statuses', $statuses, $post_id )`
+Filters the array of allowed post statuses for the chapter subscribe button in the `fictioneer_chapter_subscribe_button()` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the button to render with these statuses.
+
+**Parameters:**
+* $statuses (array) – Array of allowed post statuses.
+* $post_id (int) – Current post ID.
+
+---
+
+### `apply_filters( 'fictioneer_filter_fictioneer_chapter_index_popup_menu_statuses', $statuses, $post_id, $story_id )`
+Filters the array of allowed post statuses for the chapter index popup menu in the `fictioneer_chapter_index_popup_menu( $args )` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the menu to render with these statuses.
+
+**Parameters:**
+* $statuses (array) – Array of allowed post statuses.
+* $post_id (int) – Current post ID.
+* $story_id (int) – Story ID of the chapter.
+
+---
+
+### `apply_filters( 'fictioneer_filter_fictioneer_chapter_media_buttons_statuses', $statuses, $post_id )`
+Filters the array of allowed post statuses for the chapter media buttons in the `fictioneer_chapter_media_buttons()` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the buttons to render with these statuses.
 
 **Parameters:**
 * $statuses (array) – Array of allowed post statuses.

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -258,7 +258,7 @@ Filters the intermediate output array of the chapter micro menu in the `fictione
 
 ---
 
-### `apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_status', $statuses, $post_id )`
+### `apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', $statuses, $post_id )`
 Filters the array of allowed post statuses for the chapter navigation buttons in the `fictioneer_chapter_nav_buttons( $args, $location )` function. The default is `array('publish')`, but you could add `'private'` or `'future'` if you want to allow the navigation to render with these statuses.
 
 **Parameters:**

--- a/includes/functions/hooks/_chapter_hooks.php
+++ b/includes/functions/hooks/_chapter_hooks.php
@@ -316,10 +316,10 @@ function fictioneer_chapter_nav_buttons( $args, $location ) {
   $unlisted = get_post_meta( $post_id, 'fictioneer_chapter_hidden', true );
 
   // Filter allowed status
-  $allowed_status = apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_status', array( 'publish' ), $post_id );
+  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', array( 'publish' ), $post_id );
 
   // Do not render on hidden posts
-  if ( ! in_array( $post_status, $allowed_status ) ) {
+  if ( ! in_array( $post_status, $allowed_statuses ) ) {
     return;
   }
 

--- a/includes/functions/hooks/_chapter_hooks.php
+++ b/includes/functions/hooks/_chapter_hooks.php
@@ -316,7 +316,7 @@ function fictioneer_chapter_nav_buttons( $args, $location ) {
   $unlisted = get_post_meta( $post_id, 'fictioneer_chapter_hidden', true );
 
   // Filter allowed status
-  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', array( 'publish' ), $post_id );
+  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_statuses', array( 'publish' ), $post_id, $args, $location );
 
   // Do not render on hidden posts
   if ( ! in_array( $post_status, $allowed_statuses ) ) {
@@ -374,8 +374,10 @@ function fictioneer_chapter_subscribe_button() {
   $subscribe_buttons = fictioneer_get_subscribe_options();
   $post_status = get_post_status( get_the_ID() );
 
+  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_subscribe_button_statuses', array( 'publish' ), get_the_ID() );
+
   // Do not render on hidden posts
-  if ( $post_status !== 'publish' ) {
+  if ( ! in_array( $post_status, $allowed_statuses ) ) {
     return;
   }
 
@@ -431,8 +433,10 @@ add_action( 'fictioneer_chapter_actions_top_center', 'fictioneer_chapter_fullscr
 function fictioneer_chapter_index_popup_menu( $args ) {
   $post_status = get_post_status( get_the_ID() );
 
+  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_index_popup_menu_statuses', array( 'publish' ), get_the_ID(), $args['story_post'] );
+
   // Do not render on hidden posts
-  if ( $post_status !== 'publish' ) {
+  if ( ! in_array( $post_status, $allowed_statuses ) ) {
     return;
   }
 
@@ -499,8 +503,10 @@ add_action( 'fictioneer_chapter_actions_bottom_center', 'fictioneer_chapter_book
 function fictioneer_chapter_media_buttons() {
   $post_status = get_post_status( get_the_ID() );
 
+  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_media_buttons_statuses', array( 'publish' ), get_the_ID() );
+
   // Do not render on hidden posts
-  if ( $post_status !== 'publish' ) {
+  if ( ! in_array( $post_status, $allowed_statuses ) ) {
     return;
   }
 

--- a/includes/functions/hooks/_chapter_hooks.php
+++ b/includes/functions/hooks/_chapter_hooks.php
@@ -315,8 +315,11 @@ function fictioneer_chapter_nav_buttons( $args, $location ) {
   $post_status = get_post_status( $post_id );
   $unlisted = get_post_meta( $post_id, 'fictioneer_chapter_hidden', true );
 
+  // Filter allowed status
+  $allowed_status = apply_filters( 'fictioneer_filter_chapter_nav_buttons_allowed_status', array( 'publish' ), $post_id );
+
   // Do not render on hidden posts
-  if ( $post_status !== 'publish' ) {
+  if ( ! in_array( $post_status, $allowed_status ) ) {
     return;
   }
 

--- a/includes/functions/hooks/_chapter_hooks.php
+++ b/includes/functions/hooks/_chapter_hooks.php
@@ -374,7 +374,7 @@ function fictioneer_chapter_subscribe_button() {
   $subscribe_buttons = fictioneer_get_subscribe_options();
   $post_status = get_post_status( get_the_ID() );
 
-  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_subscribe_button_statuses', array( 'publish' ), get_the_ID() );
+  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_subscribe_button_statuses', array( 'publish' ), get_the_ID() );
 
   // Do not render on hidden posts
   if ( ! in_array( $post_status, $allowed_statuses ) ) {
@@ -433,7 +433,7 @@ add_action( 'fictioneer_chapter_actions_top_center', 'fictioneer_chapter_fullscr
 function fictioneer_chapter_index_popup_menu( $args ) {
   $post_status = get_post_status( get_the_ID() );
 
-  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_index_popup_menu_statuses', array( 'publish' ), get_the_ID(), $args['story_post'] );
+  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_index_popup_menu_statuses', array( 'publish' ), get_the_ID(), $args['story_post'] );
 
   // Do not render on hidden posts
   if ( ! in_array( $post_status, $allowed_statuses ) ) {
@@ -503,7 +503,7 @@ add_action( 'fictioneer_chapter_actions_bottom_center', 'fictioneer_chapter_book
 function fictioneer_chapter_media_buttons() {
   $post_status = get_post_status( get_the_ID() );
 
-  $allowed_statuses = apply_filters( 'fictioneer_filter_fictioneer_chapter_media_buttons_statuses', array( 'publish' ), get_the_ID() );
+  $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_media_buttons_statuses', array( 'publish' ), get_the_ID() );
 
   // Do not render on hidden posts
   if ( ! in_array( $post_status, $allowed_statuses ) ) {


### PR DESCRIPTION
This PR allow other developers to render chapter navigation/action buttons to be rendered in other statuses, which in my case are `future` status.

Let me know if there's something that need to be revised.