### PR TITLE
Allow fictioneer_get_chapter_list_items to be rendered in other statuses

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -215,6 +215,15 @@ Filters the intermediate output array in the `_chapter-header.php` partial befor
 
 ---
 
+### `apply_filters( 'fictioneer_filter_chapter_list_statuses', $statuses, $story_id )`
+Filters the list of allowed chapter statuses during building chapter lists in the `function fictioneer_get_chapter_list_items( $story_id, $data, $current_index )` function. By default, only `['publish']` chapters are shown.
+
+**Parameters:**
+* $statuses (array) – Array of chapter statuses.
+* $story_id (int) – Post ID of the story.
+
+---
+
 ### `apply_filters( 'fictioneer_filter_chapter_list_item', $item, $post, $args )`
 Filters each list item HTML string used in the chapter index popup and mobile menu section (only visible on chapter pages), build inside the `fictioneer_get_chapter_list_items()` function. Not to be confused with the chapter list shown on story pages. You can either modify the string or build a new one from the given parameters.
 

--- a/includes/functions/_helpers-templates.php
+++ b/includes/functions/_helpers-templates.php
@@ -1282,12 +1282,13 @@ if ( ! function_exists( 'fictioneer_get_chapter_list_items' ) ) {
     $chapters = fictioneer_get_story_chapter_posts( $story_id );
     $hide_icons = get_post_meta( $story_id, 'fictioneer_story_hide_chapter_icons', true ) || get_option( 'fictioneer_hide_chapter_icons' );
     $html = '';
+    $allowed_statuses = apply_filters( 'fictioneer_filter_chapter_list_statuses', [ 'publish' ], $story_id );
 
     // Loop chapters...
     foreach ( $chapters as $chapter ) {
       // Skip unpublished (in case of filtered query params)
       if (
-        $chapter->post_status !== 'publish' ||
+        ! in_array( $chapter->post_status, $allowed_statuses ) ||
         get_post_meta( $chapter->ID, 'fictioneer_chapter_hidden', true )
       ) {
         continue;


### PR DESCRIPTION
This PR is related to #50 index popup menu to let chapters items rendered in a chapter with other statuses.

Let me know if there's something that need to be revised.