### PR TITLE
Allow overriding the fictioneer_verify_unpublish_access value

### DIFF
--- a/FILTERS.md
+++ b/FILTERS.md
@@ -1605,6 +1605,16 @@ Filters the arguments for the story chapter posts query, an utility function cal
 
 ---
 
+### `apply_filters( 'fictioneer_filter_verify_unpublish_access', $authorized, $post_id, $post )`
+Filters the boolean return value of the `fictioneer_verify_unpublish_access( $post )` function. By default, this verifies current user has access to unpublished posts (not drafts).
+
+**Parameters:**
+* $authorized (boolean) – Whether the current user can unpublish the post.
+* $post_id (int) – The post ID.
+* $post (WP_Post) – The post object.
+
+---
+
 ### `apply_filters( 'fictioneer_filter_story_footer_meta', $meta_output, $args, $post )`
 Filters the intermediate output array of story meta data in the `_story-footer.php` partial before it is imploded and rendered. Contains the status, publish date, word count, age rating, and checkmark (if enabled).
 

--- a/FILTERS.md
+++ b/FILTERS.md
@@ -1609,7 +1609,7 @@ Filters the arguments for the story chapter posts query, an utility function cal
 Filters the boolean return value of the `fictioneer_verify_unpublish_access( $post )` function. By default, this verifies current user has access to unpublished posts (not drafts).
 
 **Parameters:**
-* $authorized (boolean) – Whether the current user can unpublish the post.
+* $authorized (boolean) – Whether the current user can access unpublished posts.
 * $post_id (int) – The post ID.
 * $post (WP_Post) – The post object.
 

--- a/includes/functions/_utility.php
+++ b/includes/functions/_utility.php
@@ -2769,45 +2769,46 @@ if ( ! function_exists( 'fictioneer_verify_unpublish_access' ) ) {
   function fictioneer_verify_unpublish_access( $post_id ) {
     // Setup
     $post = get_post( $post_id );
+    $authorized = false;
 
     // Always let owner to pass
     if ( get_current_user_id() === absint( $post->post_author ) ) {
-      return true;
+      $authorized = true;
     }
 
     // Always let administrators pass
     if ( current_user_can( 'manage_options' ) ) {
-      return true;
+      $authorized = true;
     }
 
     // Check capability for post type
     if ( $post->post_status === 'private' ) {
       switch ( $post->post_type ) {
         case 'post':
-          return current_user_can( 'edit_private_posts' );
+          $authorized = current_user_can( 'edit_private_posts' );
           break;
         case 'page':
-          return current_user_can( 'edit_private_pages' );
+          $authorized = current_user_can( 'edit_private_pages' );
           break;
         case 'fcn_chapter':
-          return current_user_can( 'read_private_fcn_chapters' );
+          $authorized = current_user_can( 'read_private_fcn_chapters' );
           break;
         case 'fcn_story':
-          return current_user_can( 'read_private_fcn_stories' );
+          $authorized = current_user_can( 'read_private_fcn_stories' );
           break;
         case 'fcn_recommendation':
-          return current_user_can( 'read_private_fcn_recommendations' );
+          $authorized = current_user_can( 'read_private_fcn_recommendations' );
           break;
         case 'fcn_collection':
-          return current_user_can( 'read_private_fcn_collections' );
+          $authorized = current_user_can( 'read_private_fcn_collections' );
           break;
         default:
-          return current_user_can( 'edit_others_posts' );
+          $authorized = current_user_can( 'edit_others_posts' );
       }
     }
 
     // Drafts are handled by WordPress
-    return false;
+    return apply_filters( 'fictioneer_filter_verify_unpublish_access', $authorized, $post_id, $post );
   }
 }
 


### PR DESCRIPTION
I'm not sure if this PR will be useful for others since we can disable the function by remove the related action hook. Personally, I always disable this function due to conflicts with the `future` status, but it just seems important to keep the function working.

Let me know if there's anything that needs to be revised.