### PR TITLE
Escape get_term_link() in the glossary entry link

### DIFF
--- a/singular-taxonomies.php
+++ b/singular-taxonomies.php
@@ -88,7 +88,7 @@ get_header();
               <div class="glossary__columns">
                 <?php foreach ( $tuple[1] as $term ) : ?>
                   <div class="glossary__entry">
-                    <a class="glossary__entry-head" href="<?php echo get_term_link( $term ); ?>">
+                    <a class="glossary__entry-head" href="<?php echo esc_url( get_term_link( $term ) ); ?>">
                       <div class="glossary__entry-name"><?php echo $term->name; ?></div>
                       <div class="glossary__entry-count"><?php
                         printf(


### PR DESCRIPTION
The glossary entry-heading link on `singular-taxonomies.php` echoes `get_term_link( $term )` directly into the `href`. This wraps it in `esc_url()` to match the exact `esc_url( get_term_link( $term ) )` you already use in `includes/functions/hooks/_general_hooks.php`.

For a normal term link the escaped URL is identical, so this is purely output hardening.

Really enjoyed reading through Fictioneer to find where this fit.

(full disclosure: AI helped me find this and confirm it matches your own pattern; the change and this note are mine.)
